### PR TITLE
Added argparse, '--no-init' flag, for command-line input

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,7 +103,9 @@ if __name__ == '__main__':
             print("Database initialized.")
 
         psycopg_uri = db_uri.replace(
-            'postgres', 'cockroachdb').replace('26257?', '26257/bank?')
+            'postgresql://', 'cockroachdb://').replace(
+                'postgres://', 'cockroachdb://').replace(
+                    '26257?', '26257/bank?')
         # The "cockroachdb://" prefix for the engine URL indicates that we are
         # connecting to CockroachDB using the 'cockroachdb' dialect.
         # For more information, see

--- a/main.py
+++ b/main.py
@@ -6,15 +6,17 @@
     4. Chooses five accounts at random and deletes them.
 """
 
-import random
+from argparse import ArgumentParser
 from math import floor
-import uuid
 import os
-from sqlalchemy_cockroachdb import run_transaction
+import random
+import uuid
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy_cockroachdb import run_transaction
+
 from models import Account
-from argparse import ArgumentParser
 
 # The code below inserts new accounts.
 


### PR DESCRIPTION
This change adds a `--no-init` flag to the command-line input for the connection string, to accommodate the forthcoming Alembic tutorial. 